### PR TITLE
Add og:image to Facebook Open Graph API metadata

### DIFF
--- a/_includes/open-graph.html
+++ b/_includes/open-graph.html
@@ -17,3 +17,8 @@
 {% if page.excerpt %}<meta property="og:description" content="{{ page.excerpt | strip_html }}">{% endif %}
 <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
 <meta property="og:site_name" content="{{ site.title }}">
+{% if page.image.feature %}
+<meta property="og:image" content="{{ site.url }}/images/{{ page.image.feature }}">
+{% else %}
+<meta name="og:image" content="{% if page.image.thumb %}{{ site.url }}/images/{{ page.image.thumb }}{% else %}{{ site.url }}/images/{{ site.logo }}{% endif %}">
+{% endif %}


### PR DESCRIPTION
The Theme Set-up says that this theme uses Facebook's Open Graph API for the feature and thumb images, however, the code is missing the explicitly state the image for Facebook sharing. 

According to Facebook's docs https://developers.facebook.com/docs/sharing/best-practices#tags: "og:image – This is an image associated with your media. We suggest that you use an image of at least 1200x630 pixels." So, the feature image size is the most appropriate for this, the fallback is the thumbnail or site.logo, used same syntax as twitter image.
